### PR TITLE
bump to thread-id 3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,7 @@ rust:
 - nightly
 - beta
 - stable
-- 1.4.0
-- 1.3.0
+- 1.9.0
 
 before_script:
 - |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,4 @@ readme = "README.md"
 keywords = ["thread_local", "concurrent", "thread"]
 
 [dependencies]
-thread-id = "2.0"
+thread-id = "3.0"


### PR DESCRIPTION
This will bring in the new target specific dependencies.

Note that this is a breaking change since it increases the minimum Rust version.