### PR TITLE
void 1.0.1 does not build on modern rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,5 @@ travis-ci = { repository = "Amanieu/thread_local-rs" }
 
 [dependencies]
 unreachable = "1.0"
+void = "1.0.2" # required only for minimal-versions. brought in by unreachable.
 lazy_static = "1.0"


### PR DESCRIPTION
This bumps the minimal acceptable versions in Cargo.toml to versions that build on modern rust. this gets `thread_local` working with Cargos `-Z minimal-versions`. This is part of the process of seeing how hard this is for crates to use in preparation for getting it stabilized for use in CI, specifically upstreaming the changes required to get [`criterion`](https://github.com/japaric/criterion.rs/issues/183) working with it. It is easy to use if all of your dependencies support it, but much harder if trying to impose it on them. 

I would have started with a pr to `unreachable` but it seems not to be merging pull requests.

If it is compatible with your `minimum rustc version` policy an alternative is to drop the requirement on `unreachable` and use [std::hint::unreachable_unchecked](https://doc.rust-lang.org/std/hint/fn.unreachable_unchecked.html) insted.