### PR TITLE
Use a slightly different work-around for criterion

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,12 +16,10 @@ travis-ci = { repository = "Amanieu/thread_local-rs" }
 [dependencies]
 once_cell = "1.5.2"
 
-# This is actually a dev-dependency, see https://github.com/rust-lang/cargo/issues/1596
-criterion = { version = "0.3.3", optional = true }
-
-[dev-dependencies]
+[target.'cfg(bench)'.dev-dependencies]
+# to activate, pass RUSTFLAGS="--cfg bench" until cargo does this automatically
+criterion = "0.3.3"
 
 [[bench]]
 name = "thread_local"
-required-features = ["criterion"]
 harness = false


### PR DESCRIPTION
My motivation is slightly unrelated to this package but I was hoping this general technique might be acceptable you and/or the wider Rust community.

Putting dev-dependencies as optional dependencies interferes with Debian packaging. The automated packaging tools are set up to avoid dev-dependencies; however all optional dependencies have to be installable for Debian QA purposes. Linking the QA of criterion to the QA of thread_local makes things inconvenient. We can (and do) patch this out in Debian, but apparently quite a few crates are using this current work-around, and maintaining these patches is time-consuming.

This PR changes the current work-around to a different work-around that doesn't affect automated crate-processing tools so much. This is not specific to Debian, for example other commenters in rust-lang/cargo#1596 noted that the current work-around is visible on crates.io and might mislead some users.