### PR TITLE
Inline nice function (doubles read performance)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ travis-ci = { repository = "Amanieu/thread_local-rs" }
 once_cell = "1.5.2"
 
 # This is actually a dev-dependency, see https://github.com/rust-lang/cargo/issues/1596
-criterion = { version = "0.3.3", optional = true }
+criterion = { version = "0.4.0", optional = true }
 
 [dev-dependencies]
 

--- a/src/thread_id.rs
+++ b/src/thread_id.rs
@@ -89,6 +89,7 @@ impl Drop for ThreadHolder {
 thread_local!(static THREAD_HOLDER: ThreadHolder = ThreadHolder::new());
 
 /// Get the current thread.
+#[inline]
 pub(crate) fn get() -> Thread {
     THREAD_HOLDER.with(|holder| holder.0)
 }


### PR DESCRIPTION
Output from "cargo bench --features criterion":
Before: [2.6697 ns 2.6897 ns 2.7103 ns]
After: [1.3435 ns 1.3484 ns 1.3533 ns]

this can be improved further (but sadly this requires nightly):
[1.0103 ns 1.0150 ns 1.0213 ns]