### PR TITLE
Split the thread-id TLS into 2 variables

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,13 +8,19 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/Amanieu/thread_local-rs"
 readme = "README.md"
 keywords = ["thread_local", "concurrent", "thread"]
-edition = "2018"
+edition = "2021"
+
+[features]
+# this feature provides performance improvements using nightly features
+nightly = []
 
 [badges]
 travis-ci = { repository = "Amanieu/thread_local-rs" }
 
 [dependencies]
 once_cell = "1.5.2"
+# this is required to gate `nightly` related code paths
+cfg-if = "1.0.0"
 
 # This is actually a dev-dependency, see https://github.com/rust-lang/cargo/issues/1596
 criterion = { version = "0.4.0", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,6 +65,7 @@
 
 #![warn(missing_docs)]
 #![allow(clippy::mutex_atomic)]
+#![cfg_attr(feature = "nightly", feature(thread_local))]
 
 mod cached;
 mod thread_id;


### PR DESCRIPTION
This allows the fast path to avoid a branch which checks if the TLS
destructor for the thread ID has been registered.