### PR TITLE
Set rust-version in Cargo metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/Amanieu/thread_local-rs"
 readme = "README.md"
 keywords = ["thread_local", "concurrent", "thread"]
 edition = "2021"
+rust-version = "1.59"
 
 [features]
 # this feature provides performance improvements using nightly features


### PR DESCRIPTION
Would be nice to set the `rust-version` explicitly, so that the compile error I get in a downstream crate will point out the required Rust version explicitly.