### PR TITLE
Stop checking guaranteed null buckets

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,7 +147,7 @@ impl<T: Send> Drop for ThreadLocal<T> {
             }
 
             if bucket_ptr.is_null() {
-                continue;
+                break;
             }
 
             unsafe { deallocate_bucket(bucket_ptr, this_bucket_size) };


### PR DESCRIPTION
When detecting a null-bucket we know that all following (larger) buckets will also be empty (null-buckets), so we can save some processing time by not checking these buckets needlessly.