### PR TITLE
Loosen ordering

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -250,7 +250,7 @@ impl<T: Send> ThreadLocal<T> {
             match bucket_atomic_ptr.compare_exchange(
                 ptr::null_mut(),
                 new_bucket,
-                Ordering::AcqRel,
+                Ordering::Release,
                 Ordering::Acquire,
             ) {
                 Ok(_) => new_bucket,


### PR DESCRIPTION
Use a looser ordering for swapping out an empty bucket (null ptr) for a full bucket (non-null ptr). We don't need an Acquire ordering in the success case as we don't need to establish a happens-before relationship with the write of the null ptr. We need to retain the Acquire ordering in the failure case tho as we do need to establish a happens-before relationship with the write to the allocation to which the current value of the bucket ptr points to.