### PR TITLE
Use more recent Rust features and bump MSRV

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ rust-version = "1.59"
 nightly = []
 
 [dependencies]
-once_cell = "1.5.2"
 # this is required to gate `nightly` related code paths
 cfg-if = "1.0.0"
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ thread_local = "1.1"
 
 ## Minimum Rust version
 
-This crate's minimum supported Rust version (MSRV) is 1.59.0.
+This crate's minimum supported Rust version (MSRV) is 1.70.0.
 
 ## License
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,25 +40,24 @@
 //!
 //! ```rust
 //! use thread_local::ThreadLocal;
-//! use std::sync::Arc;
 //! use std::cell::Cell;
 //! use std::thread;
 //!
-//! let tls = Arc::new(ThreadLocal::new());
+//! let tls = ThreadLocal::new();
 //!
 //! // Create a bunch of threads to do stuff
-//! for _ in 0..5 {
-//!     let tls2 = tls.clone();
-//!     thread::spawn(move || {
-//!         // Increment a counter to count some event...
-//!         let cell = tls2.get_or(|| Cell::new(0));
-//!         cell.set(cell.get() + 1);
-//!     }).join().unwrap();
-//! }
+//! thread::scope(|scope| {
+//!     for _ in 0..5 {
+//!         scope.spawn(|| {
+//!             // Increment a counter to count some event...
+//!             let cell = tls.get_or(|| Cell::new(0));
+//!             cell.set(cell.get() + 1);
+//!         });
+//!     }
+//! });
 //!
 //! // Once all threads are done, collect the counter values and return the
 //! // sum of all thread-local counter values.
-//! let tls = Arc::try_unwrap(tls).unwrap();
 //! let total = tls.into_iter().fold(0, |x, y| x + y.get());
 //! assert_eq!(total, 5);
 //! ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,13 +85,7 @@ use std::sync::atomic::{AtomicBool, AtomicPtr, AtomicUsize, Ordering};
 use thread_id::Thread;
 use unreachable::UncheckedResultExt;
 
-// Use usize::BITS once it has stabilized and the MSRV has been bumped.
-#[cfg(target_pointer_width = "16")]
-const POINTER_WIDTH: u8 = 16;
-#[cfg(target_pointer_width = "32")]
-const POINTER_WIDTH: u8 = 32;
-#[cfg(target_pointer_width = "64")]
-const POINTER_WIDTH: u8 = 64;
+const POINTER_WIDTH: u8 = usize::BITS as u8;
 
 /// The total number of buckets stored in each thread local.
 /// All buckets combined can hold up to `usize::MAX - 1` entries.


### PR DESCRIPTION
This PR was inspired by the stabilization of `std::sync::OnceLock`, which allows this crate to omit the dependency to the `once_cell` external crate. This seems like a benefit that would justify an MSRV bump. And if we're bumping MSRV anyway, then we can also use `usize::BITS` and simplify the example using scoped threads.