### PR TITLE
Bump MSRV to 1.61

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -416,7 +416,7 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.7"
+version = "1.1.8"
 dependencies = [
  "cfg-if",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/Amanieu/thread_local-rs"
 readme = "README.md"
 keywords = ["thread_local", "concurrent", "thread"]
 edition = "2021"
-rust-version = "1.59"
+rust-version = "1.61"
 
 [features]
 # this feature provides performance improvements using nightly features

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ thread_local = "1.1"
 
 ## Minimum Rust version
 
-This crate's minimum supported Rust version (MSRV) is 1.59.0.
+This crate's minimum supported Rust version (MSRV) is 1.61.0.
 
 ## License
 


### PR DESCRIPTION
Making `new` a `const fn` accidentally increased the MSRV to `1.61`, so lets advertise that.

---

See https://github.com/Amanieu/thread_local-rs/pull/67#issuecomment-1955440309