### PR TITLE
Remove once_cell dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -420,7 +420,6 @@ version = "1.1.8"
 dependencies = [
  "cfg-if",
  "criterion",
- "once_cell",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,14 +9,13 @@ repository = "https://github.com/Amanieu/thread_local-rs"
 readme = "README.md"
 keywords = ["thread_local", "concurrent", "thread"]
 edition = "2021"
-rust-version = "1.61"
+rust-version = "1.63"
 
 [features]
 # this feature provides performance improvements using nightly features
 nightly = []
 
 [dependencies]
-once_cell = "1.5.2"
 # this is required to gate `nightly` related code paths
 cfg-if = "1.0.0"
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ thread_local = "1.1"
 
 ## Minimum Rust version
 
-This crate's minimum supported Rust version (MSRV) is 1.61.0.
+This crate's minimum supported Rust version (MSRV) is 1.63.0.
 
 ## License
 


### PR DESCRIPTION
Fixes #50.  Avoids the OnceCell by making `ThreadIdManager` const-initializable. This doesn't require a MSRV bump as aggressive as #64, as it only requires 1.63 to make `Mutex::new` const. Unfortunately `BinaryHeap::new` is still not const, so this PR wraps the freelist in an Option to allow initializing it to zero. It should still be cheaper than the atomic check of a `Lazy`, and this is only done when new threads are registered.