### PR TITLE
Shrink the Thread struct

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -235,7 +235,7 @@ impl<T: Send> ThreadLocal<T> {
 
         // If the bucket doesn't already exist, we need to allocate it
         let bucket_ptr = if bucket_ptr.is_null() {
-            let new_bucket = allocate_bucket(thread.bucket_size);
+            let new_bucket = allocate_bucket(thread.bucket_size());
 
             match bucket_atomic_ptr.compare_exchange(
                 ptr::null_mut(),
@@ -248,7 +248,7 @@ impl<T: Send> ThreadLocal<T> {
                 // another thread stored a new bucket before we could,
                 // and we can free our bucket and use that one instead
                 Err(bucket_ptr) => {
-                    unsafe { deallocate_bucket(new_bucket, thread.bucket_size) }
+                    unsafe { deallocate_bucket(new_bucket, thread.bucket_size()) }
                     bucket_ptr
                 }
             }

--- a/src/thread_id.rs
+++ b/src/thread_id.rs
@@ -53,12 +53,8 @@ static THREAD_ID_MANAGER: Mutex<ThreadIdManager> = Mutex::new(ThreadIdManager::n
 /// A thread ID may be reused after a thread exits.
 #[derive(Clone, Copy)]
 pub(crate) struct Thread {
-    /// The thread ID obtained from the thread ID manager.
-    pub(crate) id: usize,
     /// The bucket this thread's local storage will be in.
     pub(crate) bucket: usize,
-    /// The size of the bucket this thread's local storage will be in.
-    pub(crate) bucket_size: usize,
     /// The index into the bucket this thread's local storage is in.
     pub(crate) index: usize,
 }
@@ -69,11 +65,17 @@ impl Thread {
         let index = id - (bucket_size - 1);
 
         Self {
-            id,
             bucket,
-            bucket_size,
             index,
         }
+    }
+
+    pub(crate) fn bucket_size(&self) -> usize {
+        1 << self.bucket
+    }
+
+    pub(crate) fn id(&self) -> usize {
+        self.index + (self.bucket_size() - 1)
     }
 }
 
@@ -184,7 +186,7 @@ cfg_if::cfg_if! {
         fn get_slow(thread: &Cell<Option<Thread>>) -> Thread {
             let new = Thread::new(THREAD_ID_MANAGER.lock().unwrap().alloc());
             thread.set(Some(new));
-            THREAD_GUARD.with(|guard| guard.id.set(new.id));
+            THREAD_GUARD.with(|guard| guard.id.set(new.id()));
             new
         }
     }
@@ -193,32 +195,32 @@ cfg_if::cfg_if! {
 #[test]
 fn test_thread() {
     let thread = Thread::new(0);
-    assert_eq!(thread.id, 0);
+    assert_eq!(thread.id(), 0);
     assert_eq!(thread.bucket, 0);
-    assert_eq!(thread.bucket_size, 1);
+    assert_eq!(thread.bucket_size(), 1);
     assert_eq!(thread.index, 0);
 
     let thread = Thread::new(1);
-    assert_eq!(thread.id, 1);
+    assert_eq!(thread.id(), 1);
     assert_eq!(thread.bucket, 1);
-    assert_eq!(thread.bucket_size, 2);
+    assert_eq!(thread.bucket_size(), 2);
     assert_eq!(thread.index, 0);
 
     let thread = Thread::new(2);
-    assert_eq!(thread.id, 2);
+    assert_eq!(thread.id(), 2);
     assert_eq!(thread.bucket, 1);
-    assert_eq!(thread.bucket_size, 2);
+    assert_eq!(thread.bucket_size(), 2);
     assert_eq!(thread.index, 1);
 
     let thread = Thread::new(3);
-    assert_eq!(thread.id, 3);
+    assert_eq!(thread.id(), 3);
     assert_eq!(thread.bucket, 2);
-    assert_eq!(thread.bucket_size, 4);
+    assert_eq!(thread.bucket_size(), 4);
     assert_eq!(thread.index, 0);
 
     let thread = Thread::new(19);
-    assert_eq!(thread.id, 19);
+    assert_eq!(thread.id(), 19);
     assert_eq!(thread.bucket, 4);
-    assert_eq!(thread.bucket_size, 16);
+    assert_eq!(thread.bucket_size(), 16);
     assert_eq!(thread.index, 4);
 }

--- a/src/thread_id.rs
+++ b/src/thread_id.rs
@@ -64,16 +64,15 @@ impl Thread {
         let bucket_size = 1 << bucket;
         let index = id - (bucket_size - 1);
 
-        Self {
-            bucket,
-            index,
-        }
+        Self { bucket, index }
     }
 
+    /// The size of the bucket this thread's local storage will be in.
     pub(crate) fn bucket_size(&self) -> usize {
         1 << self.bucket
     }
 
+    /// The thread ID obtained from the thread ID manager.
     pub(crate) fn id(&self) -> usize {
         self.index + (self.bucket_size() - 1)
     }


### PR DESCRIPTION
The `Thread` struct is `Copy` and always passed by value, so shrinking it can help reduce function call overhead, and save a tiny amount of memory overhead per thread. Both `bucket_size` and `id` are derivable from `bucket` and `index`, so add functions to compute them only when necessary, which turns out to be during (de)allocation.

Benchmark impact of this change:

```
get                     time:   [1.5243 ns 1.5258 ns 1.5273 ns]
                        change: [-12.815% -12.663% -12.512%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  1 (1.00%) low mild
  1 (1.00%) high mild
  2 (2.00%) high severe

insert                  time:   [25.034 ns 25.479 ns 26.006 ns]
                        change: [-11.590% -7.9862% -4.6845%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 16 outliers among 100 measurements (16.00%)
  3 (3.00%) high mild
  13 (13.00%) high severe
```