### PR TITLE
docs: Switch to `thread::scope()` for example

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,25 +40,24 @@
 //!
 //! ```rust
 //! use thread_local::ThreadLocal;
-//! use std::sync::Arc;
 //! use std::cell::Cell;
 //! use std::thread;
 //!
-//! let tls = Arc::new(ThreadLocal::new());
+//! let tls = ThreadLocal::new();
 //!
 //! // Create a bunch of threads to do stuff
-//! for _ in 0..5 {
-//!     let tls2 = tls.clone();
-//!     thread::spawn(move || {
-//!         // Increment a counter to count some event...
-//!         let cell = tls2.get_or(|| Cell::new(0));
-//!         cell.set(cell.get() + 1);
-//!     }).join().unwrap();
-//! }
+//! thread::scope(|scope| {
+//!     for _ in 0..5 {
+//!         scope.spawn(|| {
+//!             // Increment a counter to count some event...
+//!             let cell = tls.get_or(|| Cell::new(0));
+//!             cell.set(cell.get() + 1);
+//!         });
+//!     }
+//! });
 //!
 //! // Once all threads are done, collect the counter values and return the
 //! // sum of all thread-local counter values.
-//! let tls = Arc::try_unwrap(tls).unwrap();
 //! let total = tls.into_iter().fold(0, |x, y| x + y.get());
 //! assert_eq!(total, 5);
 //! ```


### PR DESCRIPTION
This updates the docs example to use `thread::scope()` (_valid from Rust `1.63.0` _), replacing the need for `Arc`, providing a better DX.

Originally this was contributed by @hniksic at https://github.com/Amanieu/thread_local-rs/pull/64 , but it was interleaved with other changes that have since been merged in via alternative PRs.