### PR TITLE
Fix compile error in the nightly feature

### DIFF
--- a/src/thread_id.rs
+++ b/src/thread_id.rs
@@ -131,7 +131,7 @@ cfg_if::cfg_if! {
             unsafe {
                 THREAD = Some(new);
             }
-            THREAD_GUARD.with(|guard| guard.id.set(new.id));
+            THREAD_GUARD.with(|guard| guard.id.set(new.id()));
             new
         }
     } else {


### PR DESCRIPTION
The `nightly` feature does not compile. In the `#[cfg(feature = "nightly")]` `get_slow` path, `src/thread_id.rs` has:

```rust
THREAD_GUARD.with(|guard| guard.id.set(new.id));
```

but `id` is a method on `Thread`, not a field, so this is a hard error:

```
error[E0615]: attempted to take value of method `id` on type `thread_id::Thread`
```

The non-nightly `get_slow` path already calls `new.id()` correctly. This aligns the nightly path by calling the method. The default (non-nightly) CI configuration doesn't build this feature, so the breakage isn't currently caught.

Verified with `cargo +nightly build --features nightly` and `cargo +nightly test --features nightly` (all tests pass).
