### PR TITLE
Fix reentrant get_or/get_or_try UB by returning the already-present value

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -280,6 +280,17 @@ impl<T: Send> ThreadLocal<T> {
         //   so there should not be concurrent mutable accesses into the same entry.
         // - `thread.index` is guaranteed to be in bounds within the selected bucket.
         let entry = unsafe { &*bucket_ptr.add(thread.index) };
+        // If `create` reentrantly called `get_or`/`get_or_try` on this same
+        // `ThreadLocal` from this thread, the slot is already initialized. Return
+        // the existing value and drop the one we just created, instead of
+        // overwriting it. Overwriting would leak the old value, double-count
+        // `self.values` (causing out-of-bounds iteration in `RawIter::next_mut`),
+        // and invalidate references handed out by the reentrant call.
+        // SAFETY: This function has `&self`, so there are no concurrent mutable
+        // accesses into this entry (this thread's slot is only written by this thread).
+        if let Some(existing) = unsafe { entry.as_ref() } {
+            return existing;
+        }
         let value_ptr = entry.value.get();
         // SAFETY: No concurrent read accesses are possible as this value has not
         // been initialized until now, and no data races are possible since only
@@ -648,6 +659,23 @@ mod tests {
         assert_eq!("ThreadLocal { local_data: Some(0) }", format!("{:?}", &tls));
         tls.clear();
         assert_eq!(None, tls.get());
+    }
+
+    #[test]
+    fn reentrant_get_or() {
+        let tls: ThreadLocal<Box<u32>> = ThreadLocal::new();
+        let outer = tls.get_or(|| {
+            let inner = tls.get_or(|| Box::new(1));
+            assert_eq!(**inner, 1);
+            Box::new(2)
+        });
+        // The reentrant call already populated the slot, so the outer
+        // value is discarded and the existing value is returned.
+        assert_eq!(**outer, 1);
+        // Pre-fix, `values` was double-counted and this iterated out of
+        // bounds (UB caught by Miri). Post-fix exactly one value is present.
+        let collected: Vec<u32> = tls.into_iter().map(|b| *b).collect();
+        assert_eq!(collected, vec![1]);
     }
 
     #[test]


### PR DESCRIPTION
## What

`ThreadLocal::insert` now checks whether this thread's entry is already initialized before writing to it. If it is, the freshly-created value is dropped and the existing reference is returned, instead of overwriting the slot.

## Why

If the `create` closure passed to `get_or`/`get_or_try` reentrantly calls `get_or`/`get_or_try` on the same `ThreadLocal` from the same thread, the inner call initializes this thread's slot (writes the value, sets `present`, and increments `values`) before the outer `insert` runs. The outer `insert` assumed the slot was empty and unconditionally:

- overwrote `entry.value` — leaking the reentrant value (it is never dropped) and invalidating any `&T` the reentrant call already handed out (an aliasing violation), and
- did a second `values.fetch_add`, leaving `values` (2) greater than the number of live entries (1).

Because `values` was over-counted, `RawIter::next_mut` (used by `iter_mut`/`into_iter`) kept scanning past the last real entry, advanced `bucket` to `BUCKETS`, and indexed `buckets` out of bounds — undefined behavior. Miri reports `indexing out of bounds: the len is 63 but the index is 63` on the repro. See #94 (duplicate #93).

## Testing

Added `reentrant_get_or`, which mirrors the issue #94 repro: a `create` closure reentrantly populates the slot, then the outer value is discarded and `into_iter` collects exactly one value. The test fails before this change (`assert_eq!(**outer, 1)` sees `2`) and passes after.

- `cargo test` — all pass
- `cargo fmt -- --check` — clean
- `cargo clippy -- -D warnings` — clean
- `cargo +nightly miri test` with `MIRIFLAGS=-Zmiri-strict-provenance -Zmiri-symbolic-alignment-check -Zmiri-disable-isolation` — all pass (the out-of-bounds UB is gone)

Fixes #94.
